### PR TITLE
Check hidden input exists before adding

### DIFF
--- a/readonly.js
+++ b/readonly.js
@@ -6,17 +6,20 @@
 ;(function(undefined) {
 
   var readonly = function(target) {
-    var sham = document.createElement('input');
-
-    sham.name = target.name;
-    sham.type = 'hidden';
-    sham.value = target.value;
-    sham.setAttribute('data-sham', target.name);
-
     target.setAttribute('disabled', true);
     target.setAttribute('readonly', true);
     target.classList.add('readonly');
-    target.parentNode.insertBefore(sham, target.nextSibling);
+
+    if (!hasSham(target)) {
+      var sham = document.createElement('input');
+
+      sham.name = target.name;
+      sham.type = 'hidden';
+      sham.value = target.value;
+      sham.setAttribute('data-sham', target.name);
+
+      target.parentNode.insertBefore(sham, target.nextSibling);
+    }
   };
 
   var editable = function(target) {
@@ -24,7 +27,7 @@
     target.removeAttribute('readonly');
     target.classList.remove('readonly');
 
-    if(target.nextSibling.getAttribute('data-sham') === target.name) {
+    if(hasSham(target)) {
       target.parentNode.removeChild(target.nextSibling);
     }
   };
@@ -47,6 +50,10 @@
         editable(el);
       }
     });
+  }
+
+  var hasSham = function (target) {
+    return target.nextSibling && target.nextSibling.getAttribute('data-sham') === target.name;
   }
 
   if(this.jQuery !== undefined) {


### PR DESCRIPTION
readonly() creates a hidden input with the original value without checking if the input exists already. This means if readonly() is called multiple times, multiple hidden inputs are created. When the form is submitted this results in the value for the given input having multiple values separated by commas, rather than a single value.

This change checks if the hidden input exists already when calling readonly(), and only creates it if it doesn’t exist. The check is the same as the check already made in editable()