### PR TITLE
Using nextElementSibling instead of nextSibling

### DIFF
--- a/readonly.js
+++ b/readonly.js
@@ -28,7 +28,7 @@
     target.classList.remove('readonly');
 
     if(hasSham(target)) {
-      target.parentNode.removeChild(target.nextSibling);
+      target.parentNode.removeChild(target.nextElementSibling);
     }
   };
 
@@ -53,7 +53,7 @@
   }
 
   var hasSham = function (target) {
-    return target.nextSibling && target.nextSibling.getAttribute('data-sham') === target.name;
+    return target.nextElementSibling && target.nextElementSibling.getAttribute('data-sham') === target.name;
   }
 
   if(this.jQuery !== undefined) {


### PR DESCRIPTION
Using nextElementSibling instead of nextSibling when checking for and removing the sham hidden input.

This is necessary as nextSibling can return a text node for white spaces in certain browsers (see
https://developer.mozilla.org/en-US/docs/Web/API/Node/nextSibling), so target.nextElementSibling.getAttribute in hasSham is undefined and an exception is thrown.

Please note nextSibling is still used when adding the sham hidden input, as we want it to sit right next to the element to make readonly.